### PR TITLE
Create fh-flensburg.txt

### DIFF
--- a/lib/domains/de/fh-flensburg.txt
+++ b/lib/domains/de/fh-flensburg.txt
@@ -1,0 +1,4 @@
+Hochschule Flensburg
+
+The old domain of Fachhochschule Flensburg, renamed to Hochschule Flensburg.
+The domain ist still in use for student email accounts.


### PR DESCRIPTION
This is the old domain of Fachhochschule Flensburg, renamed to Hochschule Flensburg.
The domain ist still in use for student email accounts.

Homepage: https://fh-flensburg.de redirected to https://hs-flensburg.de

Sample courses:

* https://hs-flensburg.de/studium/bachelor/mi
* https://hs-flensburg.de/studium/bachelor/ai